### PR TITLE
added noAF setup calculations; added gas, streaming, online shopping spending

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "credit-hack",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "npm": "6.14.4",
+    "node": "13.13.0"
+  },
   "dependencies": {
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amex-chase-calculator",
+  "name": "credit-hack",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "amex-chase-calc",
-  "name": "Amex vs. Chase Calculator",
+  "short_name": "credit-hack",
+  "name": "CreditHack",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/GlobalStateContainer.tsx
+++ b/src/GlobalStateContainer.tsx
@@ -83,9 +83,9 @@ function useGlobalStateContainer() {
     travelCredit: 300,
     tsaGlobalEntryCredit: 85,
     loungeAccess: 50,
-    doorDashPass: 60,
+    doorDashPass: 0,
     doorDashCredit: 30,
-    lyftPink: 60,
+    lyftPink: 0,
   });
 
   const [pointsValuation, setPointsValuation] = useState<PointsValuationState>({

--- a/src/GlobalStateContainer.tsx
+++ b/src/GlobalStateContainer.tsx
@@ -7,8 +7,11 @@ export interface AnnualExpensesState {
   groceries: number;
   flights: number;
   hotels: number;
+  gas: number;
   lyftRides: number;
   nonFlightHotelTravel: number;
+  streamingServices: number;
+  onlineShopping: number;
   other: number;
   freedomCategories: number;
 }
@@ -56,9 +59,12 @@ function useGlobalStateContainer() {
     groceries: 3000,
     flights: 1000,
     hotels: 1000,
+    gas: 1200,
     lyftRides: 500,
     nonFlightHotelTravel: 1000,
-    other: 3000,
+    streamingServices: 40 * 12,
+    onlineShopping: 1500,
+    other: 1500,
     freedomCategories: 2500,
   });
 

--- a/src/components/CompactHeader.tsx
+++ b/src/components/CompactHeader.tsx
@@ -85,6 +85,7 @@ export default function CompactHeader() {
   return (
     <AppBar className={classes.root} color="primary" position="fixed">
       <Toolbar>
+        {/*
         <IconButton
           className={classes.menuButton}
           edge="start"
@@ -93,9 +94,10 @@ export default function CompactHeader() {
         >
           <ListIcon />
         </IconButton>
+        */}
         <CardDrawer open={openDrawer} toggle={toggleDrawer} />
         <Typography className={classes.title} variant="h6">
-          {windowSize.width < 600 ? 'CC Setup Calc' : 'Credit Card Setup Calculator'}
+          CreditHack
         </Typography>
         <Button color="inherit" onClick={handleClickOpen}>
           About

--- a/src/controller/calculator.ts
+++ b/src/controller/calculator.ts
@@ -3,10 +3,9 @@ import { AnnualExpensesState, AmexBenefitsState, ChaseBenefitsState } from '../G
 enum AnnualFees {
   AmexAF = 550 + 250,
   ChaseAF = 550,
-  NoAF = 0,
 }
 
-function sumBenefits(benefits: AmexBenefitsState | ChaseBenefitsState) {
+function sumBenefitsHelper(benefits: AmexBenefitsState | ChaseBenefitsState) {
   let benefitsValue = 0;
   for (const key in benefits) {
     benefitsValue += (benefits as any)[key];
@@ -15,27 +14,86 @@ function sumBenefits(benefits: AmexBenefitsState | ChaseBenefitsState) {
   return benefitsValue;
 }
 
+/*
+ * Amex Trifecta Calculator (3 Cards)
+ *
+ * Amex Platinum Schwab - 5x Airfare, Hotel via amex travel (Schwab allows 1.25 cashback to brokerage account)
+ * Amex Gold - 4x dining, 4x US groceries
+ * Amex Blue Business Plus - 2x all purchases
+ */
 export function calculateAmexTrifecta(expenses: AnnualExpensesState, benefits: AmexBenefitsState, cpp: number): number {
-  const { dining, groceries, flights, hotels, lyftRides, nonFlightHotelTravel, other, freedomCategories } = expenses;
-  const pointsEarned = (4 * dining) + (4 * groceries) + (5 * flights)
-    + (5 * hotels) + (2 * lyftRides) + (2 * nonFlightHotelTravel) + (2 * other)
+  const {
+    dining, groceries, flights, hotels, gas, lyftRides, nonFlightHotelTravel,
+    streamingServices, onlineShopping, other, freedomCategories
+  } = expenses;
+
+  // Amex Gold caps groceries 4x multiplier up to $25k/annually; after, use BBP
+  let groceriesOverCap = 0;
+  if (groceries > 25000) {
+    groceriesOverCap = groceries - 25000;
+  }
+
+  const pointsEarned = (4 * dining) + (4 * groceries) + groceriesOverCap + (5 * flights)
+    + (5 * hotels) + (2 * gas) + (2 * lyftRides) + (2 * nonFlightHotelTravel)
+    + (2 * streamingServices) + (2 * onlineShopping) + (2 * other)
     + (2 * freedomCategories);
-  let benefitsValue = sumBenefits(benefits);
+  const benefitsValue = sumBenefitsHelper(benefits);
 
   return (pointsEarned * cpp / 100) + benefitsValue - AnnualFees.AmexAF;
 }
 
+/*
+ * Chase Trifecta Calculator (3 Cards)
+ *
+ * Chase Sapphire Reserve - 3x dining, travel
+ * Chase Freedom - 5x rotating quarterly categories up to $1.5/quarter
+ * Chase Freedom Unlimited - 1.5x all purchases
+ */
 export function calculateChaseTrifecta(expenses: AnnualExpensesState, benefits: ChaseBenefitsState, cpp: number): number {
-  const { dining, groceries, flights, hotels, lyftRides, nonFlightHotelTravel, other, freedomCategories } = expenses;
+  const {
+    dining, groceries, flights, hotels, gas, lyftRides, nonFlightHotelTravel,
+    streamingServices, onlineShopping, other, freedomCategories
+  } = expenses;
+  
   const pointsEarned = (3 * dining) + (1.5 * groceries) + (3 * flights)
-    + (3 * hotels) + (10 * lyftRides) + (3 * nonFlightHotelTravel)
-    + (1.5 * other) + (5 * freedomCategories);
-  let benefitsValue = sumBenefits(benefits);
+    + (3 * hotels) + (1.5 * gas) + (10 * lyftRides) + (3 * nonFlightHotelTravel)
+    + (1.5 * streamingServices) + (1.5 * onlineShopping) + (1.5 * other)
+    + (5 * freedomCategories);
+  const benefitsValue = sumBenefitsHelper(benefits);
 
   return (pointsEarned * cpp / 100) + benefitsValue - AnnualFees.ChaseAF;
 }
 
+/*
+ * No Annual Fee Setup Calculator (5 Cards)
+ *
+ * Wells Fargo Propel - 3% dining, gas, travel, streaming services
+ * Amex Blue Cash Everryday - 3% groceries up to $6k/annually
+ * Bank of America Cash Rewards - 3% category up to $2.5k/quarter (currently set as online shopping, but make it flexible later)
+ * Chase Freedom - 5% rotating quarterly categories up to $1.5/quarter
+ * Citi Double Cash - 2% everything
+ */
 export function calculateNoAF(expenses: AnnualExpensesState): number {
-  // const { dining, groceries, flights, hotels, lyftRides, nonFlightHotelTravel, other, freedomCategories } = expenses;
-  return 0 - AnnualFees.NoAF;
+  const {
+    dining, groceries, flights, hotels, gas, lyftRides, nonFlightHotelTravel,
+    streamingServices, onlineShopping, other, freedomCategories
+  } = expenses;
+
+  // Amex BCE caps groceries 3% back up to $6k/annually; after, use Citi DoubleCash
+  let groceriesOverCap = 0;
+  if (groceries > 6000) {
+    groceriesOverCap = groceries - 6000;
+  }
+
+  let onlineShoppingOverCap = 0;
+  if (onlineShopping > 10000) {
+    onlineShoppingOverCap = onlineShopping - 10000;
+  }
+
+  const cashBackEarned = (0.03 * dining) + (0.03 * groceries) + (0.02 * groceriesOverCap)
+    + (0.03 * flights) + (0.03 * hotels) + (0.03 * gas) + (0.03 * lyftRides) + (0.03 * nonFlightHotelTravel)
+    + (0.03 * streamingServices) + (0.03 * onlineShopping) + (0.02 * onlineShoppingOverCap)
+    + (0.02 * other) + (0.05 * freedomCategories);
+
+  return cashBackEarned;
 }

--- a/src/controller/calculator.ts
+++ b/src/controller/calculator.ts
@@ -46,7 +46,7 @@ export function calculateAmexTrifecta(expenses: AnnualExpensesState, benefits: A
  * Chase Trifecta Calculator (3 Cards)
  *
  * Chase Sapphire Reserve - 3x dining, travel
- * Chase Freedom - 5x rotating quarterly categories up to $1.5/quarter
+ * Chase Freedom - 5x rotating quarterly categories up to $1.5k/quarter
  * Chase Freedom Unlimited - 1.5x all purchases
  */
 export function calculateChaseTrifecta(expenses: AnnualExpensesState, benefits: ChaseBenefitsState, cpp: number): number {
@@ -70,7 +70,7 @@ export function calculateChaseTrifecta(expenses: AnnualExpensesState, benefits: 
  * Wells Fargo Propel - 3% dining, gas, travel, streaming services
  * Amex Blue Cash Everryday - 3% groceries up to $6k/annually
  * Bank of America Cash Rewards - 3% category up to $2.5k/quarter (currently set as online shopping, but make it flexible later)
- * Chase Freedom - 5% rotating quarterly categories up to $1.5/quarter
+ * Chase Freedom - 5% rotating quarterly categories up to $1.5k/quarter
  * Citi Double Cash - 2% everything
  */
 export function calculateNoAF(expenses: AnnualExpensesState): number {

--- a/src/views/home/AnnualExpenses.tsx
+++ b/src/views/home/AnnualExpenses.tsx
@@ -10,8 +10,11 @@ enum ExpenseCategory {
   Groceries = 'groceries',
   Flights = 'flights',
   Hotels = 'hotels',
+  Gas = 'gas',
   LyftRides = 'lyftRides',
   NonFlightHotelTravel = 'nonFlightHotelTravel',
+  SteamingServices = 'streamingServices',
+  OnlineShopping = 'onlineShopping',
   Other = 'other',
   FreedomCategories = 'freedomCategories'
 }
@@ -61,6 +64,14 @@ export default function AnnualExpenses() {
         }}
       />
       <SliderContainer
+        headerText="Gas"
+        max={15000}
+        value={annualExpenses.gas}
+        onChange={(event, newValue) => {
+          handleSliderChange(newValue as number, ExpenseCategory.Gas);
+        }}
+      />
+      <SliderContainer
         headerText="Lyft Rides"
         max={15000}
         value={annualExpenses.lyftRides}
@@ -74,6 +85,22 @@ export default function AnnualExpenses() {
         value={annualExpenses.nonFlightHotelTravel}
         onChange={(event, newValue) => {
           handleSliderChange(newValue as number, ExpenseCategory.NonFlightHotelTravel);
+        }}
+      />
+      <SliderContainer
+        headerText="Streaming Services"
+        max={15000}
+        value={annualExpenses.streamingServices}
+        onChange={(event, newValue) => {
+          handleSliderChange(newValue as number, ExpenseCategory.SteamingServices);
+        }}
+      />
+      <SliderContainer
+        headerText="Online Shopping"
+        max={15000}
+        value={annualExpenses.onlineShopping}
+        onChange={(event, newValue) => {
+          handleSliderChange(newValue as number, ExpenseCategory.OnlineShopping);
         }}
       />
       <SliderContainer

--- a/src/views/home/Summary.tsx
+++ b/src/views/home/Summary.tsx
@@ -39,16 +39,19 @@ export default function AnnualSpending() {
         })}
       </Typography>
       <Typography variant="h6" className={classes.summaryTrifectaHeader} gutterBottom>
-        Maximum Cashback Setup: {trifectaValuation.noAF.toLocaleString('en-US', {
+        No Annual Fee Cashback Setup: {trifectaValuation.noAF.toLocaleString('en-US', {
           style: 'currency',
           currency: 'USD'
         })}
       </Typography>
       <Typography variant="h6" className={classes.summaryTrifectaHeader} gutterBottom>
-        {trifectaValuation.amex > trifectaValuation.chase ? (
-          `You get ${trifectaDifference(trifectaValuation.amex, trifectaValuation.chase)} more from the Amex Trifecta Setup!`
-        ) : (
-          `You get ${trifectaDifference(trifectaValuation.chase, trifectaValuation.amex)} more from the Chase Trifecta Setup!`
+        {trifectaValuation.amex > trifectaValuation.noAF && trifectaValuation.chase > trifectaValuation.noAF ? (
+          (trifectaValuation.amex > trifectaValuation.chase) ? (
+            `You get ${trifectaDifference(trifectaValuation.amex, trifectaValuation.chase)} more from the Amex Trifecta than the Chase Trifecta!`
+          ) : (
+            `You get ${trifectaDifference(trifectaValuation.chase, trifectaValuation.amex)} more from the Chase Trifecta than the Amex Trifecta!`
+          )) : (
+          'You\'re better off with the No Annual Fee Cashback Setup!'
         )}
       </Typography>
     </CardContainer>

--- a/src/views/home/Summary.tsx
+++ b/src/views/home/Summary.tsx
@@ -6,10 +6,16 @@ import { GlobalStateContainer } from '../../GlobalStateContainer';
 import CardContainer from '../../components/CardContainer';
 
 const useStyles = makeStyles((theme) => ({
-  summaryTrifectaHeader: {
-    marginTop: 30,
-    marginLeft: 40
-  }
+  body: {
+    marginTop: 15,
+    marginLeft: 30,
+    marginRight: 30,
+  },
+  heading: {
+    marginTop: 15,
+    marginLeft: 30,
+    marginRight: 30,
+  },
 }));
 
 function trifectaDifference(num1: number, num2: number) {
@@ -22,29 +28,61 @@ function trifectaDifference(num1: number, num2: number) {
 export default function AnnualSpending() {
   const classes = useStyles();
   const { trifectaValuation } = GlobalStateContainer.useContainer();
-  // TODO: Color the valuation numbers red/green depending if they're pos/neg
   return (
     <CardContainer>
       <Typography color="secondary" variant="h6">Summary</Typography>
-      <Typography variant="h6" className={classes.summaryTrifectaHeader} gutterBottom>
+      <Typography variant="h6" className={classes.heading} gutterBottom>
         Amex Trifecta: {trifectaValuation.amex.toLocaleString('en-US', {
           style: 'currency',
           currency: 'USD'
         })}
       </Typography>
-      <Typography variant="h6" className={classes.summaryTrifectaHeader} gutterBottom>
+      <Typography className={classes.body} gutterBottom>
+        ● American Express Platinum (Schwab) - 5x airfare, hotel + benefits
+      </Typography>
+      <Typography className={classes.body} gutterBottom>
+        ● American Express Gold - 4x dining, US groceries, 3x airfare + benefits
+      </Typography>
+      <Typography className={classes.body} gutterBottom>
+        ● American Express Blue Business Plus - 2x on all purchases
+      </Typography>
+      <Typography variant="h6" className={classes.heading} gutterBottom>
         Chase Trifecta: {trifectaValuation.chase.toLocaleString('en-US', {
           style: 'currency',
           currency: 'USD'
         })}
       </Typography>
-      <Typography variant="h6" className={classes.summaryTrifectaHeader} gutterBottom>
+      <Typography className={classes.body} gutterBottom>
+        ● Chase Sapphire Reserve - 3x dining, travel + benefits
+      </Typography>
+      <Typography className={classes.body} gutterBottom>
+        ● Chase Freedom - 5x rotating quarterly categories up to $1.5k/quarter
+      </Typography>
+      <Typography className={classes.body} gutterBottom>
+        ● Chase Freedom Unlimited - 1.5x on all purchases
+      </Typography>
+      <Typography variant="h6" className={classes.heading} gutterBottom>
         No Annual Fee Cashback Setup: {trifectaValuation.noAF.toLocaleString('en-US', {
           style: 'currency',
           currency: 'USD'
         })}
       </Typography>
-      <Typography variant="h6" className={classes.summaryTrifectaHeader} gutterBottom>
+      <Typography className={classes.body} gutterBottom>
+        ● Wells Fargo Propel - 3% dining, gas, travel, streaming services
+      </Typography>
+      <Typography className={classes.body} gutterBottom>
+        ● Amex Blue Cash Everryday - 3% groceries up to $6k/annually
+      </Typography>
+      <Typography className={classes.body} gutterBottom>
+        ● Bank of America Cash Rewards - 3% category up to $2.5k/quarter
+      </Typography>
+      <Typography className={classes.body} gutterBottom>
+        ● Chase Freedom - 5% rotating quarterly categories up to $1.5k/quarter
+      </Typography>
+      <Typography className={classes.body} gutterBottom>
+        ● Citi Double Cash - 2% on all purchases
+      </Typography>
+      <Typography variant="h6" className={classes.heading} gutterBottom>
         {trifectaValuation.amex > trifectaValuation.noAF && trifectaValuation.chase > trifectaValuation.noAF ? (
           (trifectaValuation.amex > trifectaValuation.chase) ? (
             `You get ${trifectaDifference(trifectaValuation.amex, trifectaValuation.chase)} more from the Amex Trifecta than the Chase Trifecta!`


### PR DESCRIPTION
**Additions**
- Added No AF setup (5 cards setup of below) calculations
- Added `gas`, `streaming services`, and `online shopping` categories

**No AF Card Setup**
- Wells Fargo Propel - 3% dining, gas, travel, streaming services
- Amex Blue Cash Everryday - 3% groceries up to $6k/annually
- Bank of America Cash Rewards - 3% category up to $2.5k/quarter (currently set as online shopping, but make it flexible later)
- Chase Freedom - 5% rotating quarterly categories up to $1.5/quarter
- Citi Double Cash - 2% everything